### PR TITLE
Avoid returning None when no action is submitted in act

### DIFF
--- a/kits/cpp/src/agent.cpp
+++ b/kits/cpp/src/agent.cpp
@@ -15,7 +15,7 @@ json Agent::setup() {
 }
 
 json Agent::act() {
-    json actions;
+    json actions = json::object();
     for (const auto &[unitId, factory] : obs.factories[player]) {
         if (step % 4 < 3 && factory.canBuildLight(obs)) {
             actions[unitId] = factory.buildLight(obs);


### PR DESCRIPTION
@StoneT2000 I noticed that the cpp agent would cause an error in the runner when it did not submit any actions. Turns out lux expects at least an empty object, so I fixed the agent.