### PR TITLE
Fixed a broken link + capitalized Python/NumPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Interested in Season 1? Check out [last year's repository](https://github.com/Lu
 
 ## Getting Started
 
-You will need python 3.7 or above installed on your system. Once installed, you can install the Lux AI season 2 environment with
+You will need Python 3.7 or above installed on your system. Once installed, you can install the Lux AI season 2 environment with
 
 ```
 pip install --upgrade luxai2022

--- a/kits/python/README.md
+++ b/kits/python/README.md
@@ -6,7 +6,7 @@ Make sure to check our [Discord](https://discord.gg/aWJt3UAcgn) or the [Kaggle f
 
 ## Requirements
 
-You will need python 3.7 or higher and numpy installed (which should come with the dependencies you installed for the environment)
+You will need Python 3.7 or higher and NumPy installed (which should come with the dependencies you installed for the environment)
 
 ## Getting Started
 
@@ -25,7 +25,7 @@ This will run the `agent.py` code in the same folder as `main.py` and generate a
 ## Developing
 Now that you have the code up and running, you are ready to start programming and having some fun!
 
-If you haven't read it already, take a look at the [design specifications for the competition](https://www.lux-ai.org/specs-2022-beta). This will go through the rules and objectives of the competition. For a in-depth tutorial, we provide a jupyter notebook both [locally](https://github.com/Lux-AI-Challenge/Lux-Design-2022/blob/main/kits/starter_python.ipynb) and on [Kaggle](https://www.kaggle.com/code/stonet2000/lux-ai-season-2-jupyter-notebook-tutorial#Lux-AI-Season-2-Jupyter-Notebook-Tutorial---Python-Kit)
+If you haven't read it already, take a look at the [design specifications for the competition](https://www.lux-ai.org/specs-2022-beta). This will go through the rules and objectives of the competition. For a in-depth tutorial, we provide a jupyter notebook both [locally](https://github.com/Lux-AI-Challenge/Lux-Design-2022/blob/main/kits/python/starter_python.ipynb) and on [Kaggle](https://www.kaggle.com/code/stonet2000/lux-ai-season-2-jupyter-notebook-tutorial#Lux-AI-Season-2-Jupyter-Notebook-Tutorial---Python-Kit)
 
 All of our kits follow a common API through which you can use to access various functions and properties that will help you develop your strategy and bot. The markdown version is here: https://github.com/Lux-AI-Challenge/Lux-Design-2022/blob/main/kits/README.md, which also describes the observation and action structure/spaces.
 


### PR DESCRIPTION
The link to the local notebook was missing part of the path. 
Capitalized Python and NumPy as they were used as the name of the package.