### PR TITLE
fix(js): add missing info field

### DIFF
--- a/kits/js/main.py
+++ b/kits/js/main.py
@@ -43,7 +43,7 @@ def agent(observation, configuration):
         t = Thread(target=enqueue_output, args=(agent_process.stderr, q_stderr))
         t.daemon = True # thread dies with the program
         t.start()
-    data = json.dumps(dict(obs=json.loads(observation.obs), step=observation.step, remainingOverageTime=observation.remainingOverageTime, player=observation.player, reward=observation.reward))
+    data = json.dumps(dict(obs=json.loads(observation.obs), step=observation.step, remainingOverageTime=observation.remainingOverageTime, player=observation.player, reward=observation.reward, info=configuration))
     agent_process.stdin.write(f"{data}\n".encode())
     agent_process.stdin.flush()
 


### PR DESCRIPTION
The js agent is missing `input["info"]` from the input:
https://github.com/Lux-AI-Challenge/Lux-Design-2022/blob/ae350069693a4529de7668491bc0478eba5f5ad4/kits/js/agent.js#L109

I believe it comes from `configuration` in `def agent(observation, configuration)`.

Tested to be working with `kaggle-environments` and can pass submission validation, but cannot run with `luxai2022`.