### PR TITLE
Fix double newline on agent stderr

### DIFF
--- a/luxai_runner/process.py
+++ b/luxai_runner/process.py
@@ -63,7 +63,7 @@ class BotProcess:
             while not stream.at_eof():
                 data = await stream.readline()
                 line = data.decode()
-                if self.live_log: self.log.err(line)
+                if self.live_log: self.log.err(line, end="")
                 else: self.stderr_queue.append(line)
         asyncio.create_task(log_stream(self._agent_process.stderr))
         # await asyncio.gather(watch(self._agent_process.stderr, 'E:'))


### PR DESCRIPTION
All stderr from agents is currently printed out with an extra newline after every line when running using the CLI. This PR removes that extra newline, which makes multi-line log messages (like stack traces) more readable in my opinion.

Before:
![](https://user-images.githubusercontent.com/14951909/201782995-736fafaf-8fcb-46d0-a7dc-05091c737ffd.png)

After:
![](https://user-images.githubusercontent.com/14951909/201783031-dfe1ad1b-f113-48b2-812d-f91764f6741f.png)