### PR TITLE
Fix ValueError: I/O operation on closed pipe error on Windows 10

### DIFF
--- a/luxai_runner/episode.py
+++ b/luxai_runner/episode.py
@@ -145,4 +145,7 @@ class Episode:
         if save_replay:
             self.save_replay(replay)
 
+        for player in players.values():
+            await player.proc.cleanup()
+
         return rewards

--- a/luxai_runner/process.py
+++ b/luxai_runner/process.py
@@ -92,3 +92,7 @@ class BotProcess:
         #         stderrs.append((await line).decode())
         #         # stderrs.append(line.decode())
         # return " ".join(stderrs)
+
+    async def cleanup(self):
+        self._agent_process.terminate()
+        await self._agent_process.wait()

--- a/luxai_runner/process.py
+++ b/luxai_runner/process.py
@@ -95,5 +95,6 @@ class BotProcess:
         # return " ".join(stderrs)
 
     async def cleanup(self):
+        self._agent_process._transport.close()
         self._agent_process.terminate()
         await self._agent_process.wait()

--- a/luxai_runner/process.py
+++ b/luxai_runner/process.py
@@ -63,7 +63,8 @@ class BotProcess:
             while not stream.at_eof():
                 data = await stream.readline()
                 line = data.decode()
-                if self.live_log: self.log.err(line)
+                if stream.at_eof() and len(line) == 0: break
+                elif self.live_log: self.log.err(line)
                 else: self.stderr_queue.append(line)
         asyncio.create_task(log_stream(self._agent_process.stderr))
         # await asyncio.gather(watch(self._agent_process.stderr, 'E:'))


### PR DESCRIPTION
This fix references [this issue](https://github.com/Lux-AI-Challenge/Lux-Design-2022/issues/80). I don't fully understand what's going on to cause the issue, but it seems that without properly waiting for subprocesses to terminate, we get errors from pending I/O operations. I went ahead and added a cleanup method to be run at the end of execution for an episode, which seems to resolve the issue on windows. 

With better understanding of the bug, someone might be able to make a cleaner solution this what I have here.