### PR TITLE
#104: fix for to_json for numpy integers and tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To stay up to date on changes and updates to the competition and the engine, wat
 ## Community Tools
 As the community builds tools for the competition, we will post them here!
 
+3rd Party Viewer - https://github.com/jmerle/lux-eye-2022
+
 ## Contributing
 See the [guide on contributing](https://github.com/Lux-AI-Challenge/Lux-Design-2022/blob/main/CONTRIBUTING.md)
 

--- a/luxai_runner/utils.py
+++ b/luxai_runner/utils.py
@@ -1,15 +1,19 @@
 import numpy as np
-def to_json(state):
-    if isinstance(state, np.ndarray):
-        return state.tolist()
-    elif isinstance(state, np.int64) or isinstance(state, np.int32):
-        return state.tolist()
-    elif isinstance(state, list):
-        return [to_json(s) for s in state]
-    elif isinstance(state, dict):
+
+
+def to_json(obj):
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    elif isinstance(obj, np.integer):
+        return int(obj)
+    elif isinstance(obj, np.floating):
+        return float(obj)
+    elif isinstance(obj, list) or isinstance(obj, tuple):
+        return [to_json(s) for s in obj]
+    elif isinstance(obj, dict):
         out = {}
-        for k in state:
-            out[k] = to_json(state[k])
+        for k in obj:
+            out[k] = to_json(obj[k])
         return out
     else:
-        return state
+        return obj


### PR DESCRIPTION
Fixes #104 

Now:
* all np.integers are converted to int
* tuples are handled like lists
* added np.float conversiont to float

I also renamed state to obj, since reflects better what is happening as it is a nested object conversion.