### PR TITLE
Fix inability to run Java programs with Luxai2022 runner

### DIFF
--- a/luxai_runner/process.py
+++ b/luxai_runner/process.py
@@ -37,9 +37,13 @@ class BotProcess:
             cwd = "."
         self.log.info(f"Beginning {self.command} {self.file_path}")
         # self._agent_process = Popen([self.command, os.path.basename(self.file_path)], stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
+
+        base_file_path = os.path.basename(self.file_path)   
+        if self.command == "java" and base_file_path.endswith(".java"):
+            base_file_path = base_file_path[:-5]
         self._agent_process = await asyncio.create_subprocess_exec(
             self.command,
-            os.path.basename(self.file_path),
+            base_file_path,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
If you try to run a java program using the luxai2022 command, we will fail with the following error:

```
Error: Could not find or load main class $CLASS_NAME.java
```

The problem is we are trying to execute the following command:

```
java $CLASS_NAME.java
```

Which is not the proper compilation/execution pattern for java. Instead, after you run `javac $CLASS_NAME.java`, you are expected to run your newly compiled code with the following command: `java $CLASS_NAME`, where we neglect the file extension. I've gone ahead and done this manually before we create the subprocess and it seems to work in my most basic of tests.