### PR TITLE
Add unit action_queue to C++ json serialization

### DIFF
--- a/kits/cpp/src/lux/unit.hpp
+++ b/kits/cpp/src/lux/unit.hpp
@@ -37,5 +37,5 @@ namespace lux {
 
         UnitAction recharge(int64_t amount, bool repeat = true) const;
     };
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Unit, team_id, unit_id, power, unit_type, pos, cargo)
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Unit, team_id, unit_id, power, unit_type, pos, cargo, action_queue)
 }  // namespace lux


### PR DESCRIPTION
Action queues for units weren't getting populated because it was missing from the json serialization.