### PR TITLE
C++ kit config bug

### DIFF
--- a/kits/cpp/main.py
+++ b/kits/cpp/main.py
@@ -43,7 +43,7 @@ def agent(observation, configuration):
         t = Thread(target=enqueue_output, args=(agent_process.stderr, q_stderr))
         t.daemon = True # thread dies with the program
         t.start()
-    data = json.dumps(dict(obs=json.loads(observation.obs), step=observation.step, remainingOverageTime=observation.remainingOverageTime, player=observation.player, reward=observation.reward))
+    data = json.dumps(dict(obs=json.loads(observation.obs), step=observation.step, remainingOverageTime=observation.remainingOverageTime, player=observation.player, info=configuration))
     agent_process.stdin.write(f"{data}\n".encode())
     agent_process.stdin.flush()
 


### PR DESCRIPTION
Same issue as was in the JS bot that was fixed in #96. `main.py` did not give the proper configuration to the agent binary, resulting in kaggle throwing an error.