### PR TITLE
[Update] bump ubuntu version to get higher cmake version

### DIFF
--- a/kits/cpp/Dockerfile
+++ b/kits/cpp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update
 RUN apt install build-essential cmake curl -y


### PR DESCRIPTION
When running `./create_submission.sh` it's possible that it will fail due to CMake version being < `3.12` which is required.

By updating the base image we ensuere that CMake `3.16` is used. Successfully tested locally.