### PR TITLE
[cpp] Fix repeat field type

### DIFF
--- a/kits/cpp/src/lux/action.hpp
+++ b/kits/cpp/src/lux/action.hpp
@@ -43,7 +43,7 @@ namespace lux {
         int64_t   distance;
         Resource  resource;
         int64_t   amount;
-        bool      repeat;
+        int64_t   repeat;
 
         UnitAction() = default;
         UnitAction(UnitAction::RawType raw_);


### PR DESCRIPTION
Was missed when updating the kit to 1.1.0