### PR TITLE
[Fix] repeat type in action: bool to int

### DIFF
--- a/kits/cpp/src/lux/action.hpp
+++ b/kits/cpp/src/lux/action.hpp
@@ -43,7 +43,7 @@ namespace lux {
         int64_t   distance;
         Resource  resource;
         int64_t   amount;
-        bool      repeat;
+        int64_t   repeat;
 
         UnitAction() = default;
         UnitAction(UnitAction::RawType raw_);


### PR DESCRIPTION
A poor `bool` was forgotten in the v1.1.0 refactor. It's evolving! `bool` is now `int64_t`!

Why: with `bool` any repeat is converted to `0/1`.