### PR TITLE
Fix several bugs in compute_water_info and make the lichen boundry stable.

### DIFF
--- a/luxai2022/factory.py
+++ b/luxai2022/factory.py
@@ -58,7 +58,7 @@ def compute_water_info(init: np.ndarray, MIN_LICHEN_TO_SPREAD: int, lichen: np.n
                 seen.add(tuple(check_pos))
                 frontier.append(check_pos)
 
-        if can_grow:
+        if can_grow or (lichen_strains[pos[0], pos[1]] == strain_id):
             grow_lichen_positions.add((pos[0], pos[1]))
     return grow_lichen_positions
 

--- a/luxai2022/factory.py
+++ b/luxai2022/factory.py
@@ -40,10 +40,15 @@ def compute_water_info(init: np.ndarray, MIN_LICHEN_TO_SPREAD: int, lichen: np.n
         can_grow = True
         for move_delta in move_deltas[1:]:
             check_pos = pos + move_delta
-            if (check_pos[0], check_pos[1]) in seen: continue
             # check surrounding tiles on the map
-            if check_pos[0] < 0 or check_pos[1] < 0 or check_pos[0] >= W or check_pos[1] >= H: continue
+            if check_pos[0] < 0 or check_pos[1] < 0 or check_pos[0] >= H or check_pos[1] >= W: continue
             adj_strain = lichen_strains[check_pos[0], check_pos[1]]
+            if (check_pos[0], check_pos[1]) in seen:
+                # even if it is seen, we still need to check its strain, to decide weather current pos is growable.
+                # but there is no need to add it to the frontier again.
+                if adj_strain != -1 and adj_strain != strain_id:
+                    can_grow = False
+                continue
             if adj_strain == -1:
                 if pos_lichen >= MIN_LICHEN_TO_SPREAD:
                     # adjacent tile is empty and isn't a resource and the current tile has enough lichen to spread


### PR DESCRIPTION
If a tile is already expanded, it should be added to the positions to water unconditionally. However, the current water info computation did not, and results in a strange behavior of lichen growth -- the unstable boundary. 

For example. consider the following case on a 1x4 map. There are two lichen strains, A and B. A and B initially occupy tiles 1 and 4. In the first turn, they both water, then they expanded to cell 2 and cell 3, respectively. Next turn, they both water again. However, they lost cell 2 and cell 3, respectively. This is because cell 2 is next to cell 3, which belongs to another strain, so it cannot be watered by A. Similarly, cell 3 cannot be watered by B. Finally, A lost cell 2, and B lost cell 3. If A and B keep watering, the two patterns will periodically appear, resulting in an unstable boundary, even if strains A and B belong to the same player. 

```
|A|    |A|    |A|    |A|
| | -> |A| -> | | -> |A| -> ...
| |    |B|    | |    |B|
|B|    |B|    |B|    |B|
```

In short, if a tile is already expanded and reachable from the factory, it should be added to the positions to water unconditionally, no matter whether its neighbors belong to other strains or not.