### PR TITLE
Fix factory water cost calculation in C++ kit

### DIFF
--- a/kits/cpp/src/lux/factory.cpp
+++ b/kits/cpp/src/lux/factory.cpp
@@ -52,7 +52,7 @@ namespace lux {
         };
         int64_t sum =
             std::accumulate(obs.board.lichen_strains.begin(), obs.board.lichen_strains.end(), 0, countMatchingStrains);
-        return std::ceil(sum / obs.config.LICHEN_WATERING_COST_FACTOR) + 1;
+        return std::ceil(sum / obs.config.LICHEN_WATERING_COST_FACTOR);
     }
 
     bool Factory::canWater(const Observation &obs) const { return cargo.water >= waterCost(obs); }


### PR DESCRIPTION
This was changed in the python kit a few days ago. @StoneT2000 feel free to ping me when you change aspects of the python kit, so I can adjust this kit at the same time / only with a slight delay.