### PR TITLE
Fix a severe bug in transfer action

### DIFF
--- a/luxai2022/env.py
+++ b/luxai2022/env.py
@@ -329,7 +329,7 @@ class LuxAI2022(ParallelEnv):
             factory_id = f"factory_{self.state.board.factory_occupancy_map[transfer_pos.x, transfer_pos.y]}"
             if factory_id in self.state.factories[unit.team.agent]:
                 factory = self.state.factories[unit.team.agent][factory_id]
-                actually_transferred = factory.add_resource(transfer_action.resource, transfer_action.transfer_amount)
+                actually_transferred = factory.add_resource(transfer_action.resource, transfer_amount)
             elif units_there is not None:
                 assert len(units_there) == 1, "Fatal error here, this is a bug"
                 target_unit = units_there[0]


### PR DESCRIPTION
Fix a severe bug in transfer action, which allow the robot to transfer any amount of resources to a factory, even if it does not have enough resources. Because we do not check transfer amount is valid or not, we cannot trust the amount given by users now. Before adding it to a factory, we must take a minimum between the transfer amount and the robot cargo stock.