### PR TITLE
Fix a bug in env.step that may lead to crash.

### DIFF
--- a/luxai2022/env.py
+++ b/luxai2022/env.py
@@ -572,7 +572,7 @@ class LuxAI2022(ParallelEnv):
                             self.state.units[agent][unit_id].action_queue = formatted_actions
                 except Exception as e:
                     # catch errors when trying to format unit or factory actions
-                    print(e.with_traceback())
+                    print(e.with_traceback(None))
                     failed_agents[agent] = True
         
             # 2. store actions by type


### PR DESCRIPTION
Fix a bug in env.step that may lead to crashing. When updating the action queue, all exceptions will be caught and printed. However,  `e.with_traceback()` takes one argument, and nothing is given. This will lead to the whole game crashing. 

The most common case to trigger the crash is when a player provides actions for a non-existing robot or a robot he/she does not own.