### PR TITLE
Fix bug: factory_occupancy_map using the same id for all factories 

### DIFF
--- a/kits/python/lux/kit.py
+++ b/kits/python/lux/kit.py
@@ -85,7 +85,7 @@ def obs_to_game_state(step, env_cfg: EnvConfig, obs):
             )
             factory.cargo = cargo
             factories[agent][unit_id] = factory
-            factory_occupancy_map[factory.pos_slice] = factory.team_id
+            factory_occupancy_map[factory.pos_slice] = factory.strain_id
     teams = dict()
     for agent in obs["teams"]:
         team_data = obs["teams"][agent]

--- a/kits/python/lux/kit.py
+++ b/kits/python/lux/kit.py
@@ -149,3 +149,4 @@ class GameState:
     # various utility functions
     def is_day(self):
         return self.real_env_steps % self.env_cfg.CYCLE_LENGTH < self.env_cfg.DAY_LENGTH
+


### PR DESCRIPTION
In the py-kit factory_occupancy_map uses the team_id instead of the factory id. Therefore it always shows factory_0 for player_0 no matter which factory_id it actually is. This causes crashes when factory_0/1 die.