### PR TITLE
Fix: make transfer action irrelevant to unit_id.

### DIFF
--- a/luxai2022/env.py
+++ b/luxai2022/env.py
@@ -323,10 +323,21 @@ class LuxAI2022(ParallelEnv):
         return failed_agents
 
     def _handle_transfer_actions(self, actions_by_type: ActionsByType):
+        # It is important to first sub resource from all units, and then add
+        # resource to targets. Only When splitted into two loops, the transfer
+        # action is irrelevant to unit id.
+
+        # sub from unit cargo
         for unit, transfer_action in actions_by_type["transfer"]:
             transfer_action: TransferAction
             transfer_amount = unit.sub_resource(transfer_action.resource, transfer_action.transfer_amount)
+            transfer_action.transfer_amount = transfer_amount
+
+        # add to target cargo
+        for unit, transfer_action in actions_by_type["transfer"]:
+            transfer_action: TransferAction
             transfer_pos: Position = unit.pos + move_deltas[transfer_action.transfer_dir]
+            transfer_amount = transfer_action.transfer_amount
             units_there = self.state.board.get_units_at(transfer_pos)
 
             # if there is a factory, we prefer transferring to that entity

--- a/luxai2022/env.py
+++ b/luxai2022/env.py
@@ -328,16 +328,16 @@ class LuxAI2022(ParallelEnv):
         # action is irrelevant to unit id.
 
         # sub from unit cargo
+        amount_list = []
         for unit, transfer_action in actions_by_type["transfer"]:
             transfer_action: TransferAction
             transfer_amount = unit.sub_resource(transfer_action.resource, transfer_action.transfer_amount)
-            transfer_action.transfer_amount = transfer_amount
+            amount_list.append(transfer_amount)
 
         # add to target cargo
-        for unit, transfer_action in actions_by_type["transfer"]:
+        for (unit, transfer_action), transfer_amount in zip(actions_by_type["transfer"], amount_list):
             transfer_action: TransferAction
             transfer_pos: Position = unit.pos + move_deltas[transfer_action.transfer_dir]
-            transfer_amount = transfer_action.transfer_amount
             units_there = self.state.board.get_units_at(transfer_pos)
 
             # if there is a factory, we prefer transferring to that entity


### PR DESCRIPTION
Before, the transfer result relies on the unit_id because the transfer is executed from units with small id to ones with big id. For example, consider three light robots, A, B, and C, with a cargo space of 100. Initially, they both have 80 water. Now, A wants to transfer 80 water to B, and B wants to transfer 80 water to C.
```
           A   B   C
initial:  80  80  80
action: A -80-> B -80-> C
```

If `A.unit_id` < `B.unit_id`, then A transfers first. After transfer, B has 100 water because of the cargo space limit. Then B transfers 80 water to C and has only 20 left.

If `B.unit_id` < `A.unit_id`, then B transfer first. After transfer, B has 0 water. Then A transfer 80 water to B, and B finally has 80.
```
          A   B   C
final:    0  20 100,  if A.unit_id < B.unit_id
          0  80 100,  if B.unit_id < A.unit_id
```

Conceptually, all transfer actions happen simultaneously and should not rely on the unit id. This commit fixes this issue and implements the id-irrelevant transfer. In this commit, we first take away resources/power that is going to be transferred from all robots before adding resources to any target. Then we add them to targets altogether and perform the cargo space limit checks.