### PR TITLE
Store strain id in occupancy map instead of team id

### DIFF
--- a/kits/cpp/src/agent.cpp
+++ b/kits/cpp/src/agent.cpp
@@ -34,13 +34,12 @@ json Agent::act() {
             actions[unitId] = factory.buildLight(obs);
         } else if (factory.canBuildHeavy(obs)) {
             actions[unitId] = factory.buildHeavy(obs);
-        }
-        if (factory.canWater(obs)) {
+        } else if (factory.canWater(obs)) {
             actions[unitId] = factory.water(obs);  // Alternatively set it to lux::FactoryAction::Water()
         }
     }
     for (const auto &[unitId, unit] : obs.units[player]) {
-        for (int64_t i = 0; i < 5; ++i) {
+        for (int64_t i = 1; i < 5; ++i) {
             auto direction = lux::directionFromInt(i);
             auto moveCost = unit.moveCost(obs, direction);
             if (moveCost >= 0 && unit.power >= moveCost + unit.actionQueueCost(obs)) {
@@ -53,5 +52,7 @@ json Agent::act() {
     }
     // dump your created actions in a file by uncommenting this line
     // lux::dumpJsonToFile("last_actions.json", actions);
+    // or log them by uncommenting this line
+    // LUX_LOG(actions);
     return actions;
 }

--- a/kits/cpp/src/lux/observation.cpp
+++ b/kits/cpp/src/lux/observation.cpp
@@ -39,15 +39,15 @@ namespace lux {
         for (const auto &[_, factories] : o.factories) {
             for (const auto &[__, factory] : factories) {
                 // TODO Is there a guarantee, that the factories are not placed on the edge??
-                o.board.factory_occupancy[factory.pos.x - 1][factory.pos.y - 1] = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x - 1][factory.pos.y]     = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x - 1][factory.pos.y + 1] = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x][factory.pos.y - 1]     = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x][factory.pos.y]         = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x][factory.pos.y + 1]     = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x + 1][factory.pos.y - 1] = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x + 1][factory.pos.y]     = factory.team_id;
-                o.board.factory_occupancy[factory.pos.x + 1][factory.pos.y + 1] = factory.team_id;
+                o.board.factory_occupancy[factory.pos.x - 1][factory.pos.y - 1] = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x - 1][factory.pos.y]     = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x - 1][factory.pos.y + 1] = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x][factory.pos.y - 1]     = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x][factory.pos.y]         = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x][factory.pos.y + 1]     = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x + 1][factory.pos.y - 1] = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x + 1][factory.pos.y]     = factory.strain_id;
+                o.board.factory_occupancy[factory.pos.x + 1][factory.pos.y + 1] = factory.strain_id;
             }
         }
         // set unit configs

--- a/kits/cpp/src/lux/unit.cpp
+++ b/kits/cpp/src/lux/unit.cpp
@@ -20,8 +20,13 @@ namespace lux {
             || static_cast<size_t>(target.y) >= obs.board.rubble.size()) {
             return -1;
         }
-        auto factoryTeam = obs.board.factory_occupancy[target.x][target.y];
-        if (factoryTeam != -1 && team_id != factoryTeam) {
+        const std::string player = team_id == 0 ? "player_0" : "player_1";
+        LUX_ASSERT(obs.teams.find(player) != obs.teams.end(), "must find fitting team");
+        const auto &strains        = obs.teams.find(player)->second.factory_strains;
+        int64_t     strainAtTarget = obs.board.factory_occupancy[target.x][target.y];
+        if (strainAtTarget != -1 && std::none_of(strains.begin(), strains.end(), [strainAtTarget](int64_t s) -> bool {
+                return s == strainAtTarget;
+            })) {
             return -1;
         }
         auto rubble  = obs.board.rubble[target.x][target.y];


### PR DESCRIPTION
Adjusts cpp kit to new changes.