### PR TITLE
Add dependency checks for cpp kit

### DIFF
--- a/kits/cpp/compile.sh
+++ b/kits/cpp/compile.sh
@@ -19,6 +19,8 @@ abort() {
 
 [ -f "$PWD/compile.sh" ] || abort "script not running from within the build directory"
 [ -z "$(which cmake)" ] && abort "cmake must be installed"
+[ -z "$(which make)" ] && abort "make must be installed"
+[ -z "$(which curl)" ] && abort "curl must be installed"
 
 build_warnings="ON"
 build_debug="OFF"


### PR DESCRIPTION
The current compilation helper only checked that cmake is installed. This adds checks for the other required tools due to #139 
The check for a suitable cpp compiler is done by cmake.